### PR TITLE
Add function visitors

### DIFF
--- a/birdie_snapshots/snap_dummy_src_no_trailing_underscore_gleam.accepted
+++ b/birdie_snapshots/snap_dummy_src_no_trailing_underscore_gleam.accepted
@@ -1,0 +1,10 @@
+---
+version: 1.1.2
+title: ./snap_dummy/src/no_trailing_underscore.gleam
+---
+Path: ./snap_dummy/src/no_trailing_underscore.gleam
+
+Location Identifier: with_trailing_
+Rule: NoTrailingUnderscore
+Error: Trailing underscore in function name
+Details: We don't like no trailing underscores.

--- a/snap_dummy/src/no_trailing_underscore.gleam
+++ b/snap_dummy/src/no_trailing_underscore.gleam
@@ -1,0 +1,7 @@
+pub fn with_trailing_() {
+  1
+}
+
+pub fn without_trailing() {
+  1
+}

--- a/src/code_review.gleam
+++ b/src/code_review.gleam
@@ -182,11 +182,7 @@ fn visit_expressions(input: glance.Module, rules: List(Rule)) -> List(RuleError)
     list.flat_map(rules, fn(rule) {
       list.flat_map(rule.expression_visitors, fn(visitor) { visitor(expr) })
       |> list.map(fn(error) {
-        RuleError(
-          ..error,
-          rule: rule.name,
-          location_identifier: location_identifier,
-        )
+        RuleError(..error, location_identifier: location_identifier)
       })
     })
   }

--- a/src/code_review.gleam
+++ b/src/code_review.gleam
@@ -206,24 +206,30 @@ fn visit_expressions(input: glance.Module, rules: List(Rule)) -> List(RuleError)
       list.append(errors_for_func, acc0),
     )
 
-    let expr: glance.Expression = case stmt {
-      glance.Use(_, expr) -> expr
-      glance.Assignment(value: val, ..) -> val
-      glance.Expression(expr) -> expr
-    }
-
     list.append(
-      do_visit_expressions(expr, [], fn(expr) {
-        apply_visitor(expr, rules, fn(rule) { rule.expression_visitors })
+      visit_statement(stmt, rules)
         |> list.map(fn(error) {
-          RuleError(..error, location_identifier: func.name)
-        })
+        RuleError(..error, location_identifier: func.name)
       }),
       acc1,
     )
   }
 
   results_after_functions
+}
+
+fn visit_statement(
+  statement: glance.Statement,
+  rules: List(Rule),
+) -> List(RuleError) {
+  let expr: glance.Expression = case statement {
+    glance.Use(_, expr) -> expr
+    glance.Assignment(value: val, ..) -> val
+    glance.Expression(expr) -> expr
+  }
+  do_visit_expressions(expr, [], fn(expr) {
+    apply_visitor(expr, rules, fn(rule) { rule.expression_visitors })
+  })
 }
 
 fn apply_visitor(

--- a/src/code_review.gleam
+++ b/src/code_review.gleam
@@ -143,17 +143,9 @@ fn read_project(project_root_path: String) -> Result(KnowledgeBase, WhingeError)
 
 fn visit_knowledge_base(kb: KnowledgeBase, rules: List(Rule)) -> List(RuleError) {
   use acc, Module(path, module) <- list.fold(kb.src_modules, [])
-  visit_module(path, rules, module)
-  |> list.append(acc)
-}
-
-fn visit_module(
-  path: String,
-  rules: List(Rule),
-  input_module: glance.Module,
-) -> List(RuleError) {
-  visit_expressions(input_module, rules)
+  visit_module(module, rules)
   |> list.map(fn(error) { RuleError(..error, path: path) })
+  |> list.append(acc)
 }
 
 // Extracts all the top level functions out of a glance module.
@@ -174,7 +166,7 @@ fn extract_constants(from input: glance.Module) -> List(glance.Constant) {
   })
 }
 
-fn visit_expressions(input: glance.Module, rules: List(Rule)) -> List(RuleError) {
+fn visit_module(input: glance.Module, rules: List(Rule)) -> List(RuleError) {
   let funcs = extract_functions(input)
   let consts = extract_constants(input)
 

--- a/src/code_review.gleam
+++ b/src/code_review.gleam
@@ -158,17 +158,10 @@ fn extract_functions(from input: glance.Module) -> List(glance.Function) {
     })
 }
 
-fn extract_constants(from input: glance.Module) -> List(glance.Constant) {
-  let glance.Module(constants: consts, ..) = input
-  list.map(consts, fn(const_) {
-    let glance.Definition(_, c) = const_
-    c
-  })
-}
-
 fn visit_module(input: glance.Module, rules: List(Rule)) -> List(RuleError) {
+  let glance.Module(constants: constants, ..) = input
+
   let funcs = extract_functions(input)
-  let consts = extract_constants(input)
 
   let f = fn(location_identifier, expr) {
     apply_visitor(expr, rules, fn(rule) { rule.expression_visitors })
@@ -179,7 +172,8 @@ fn visit_module(input: glance.Module, rules: List(Rule)) -> List(RuleError) {
 
   // Visit all constants
   let results_after_const: List(RuleError) =
-    list.fold(consts, [], fn(const_acc, c) {
+    list.fold(constants, [], fn(const_acc, constant_with_definition) {
+      let glance.Definition(_, c) = constant_with_definition
       do_visit_expressions(c.value, const_acc, fn(expr) { f(c.name, expr) })
     })
 

--- a/src/code_review.gleam
+++ b/src/code_review.gleam
@@ -202,7 +202,15 @@ fn visit_expressions(input: glance.Module, rules: List(Rule)) -> List(RuleError)
       glance.Expression(expr) -> expr
     }
 
-    do_visit_expressions(expr, acc1, fn(expr) { f(func.name, expr) })
+    list.append(
+      do_visit_expressions(expr, [], fn(expr) {
+        apply_visitor(expr, rules, fn(rule) { rule.expression_visitors })
+        |> list.map(fn(error) {
+          RuleError(..error, location_identifier: func.name)
+        })
+      }),
+      acc1,
+    )
   }
 
   results_after_functions

--- a/src/code_review.gleam
+++ b/src/code_review.gleam
@@ -148,20 +148,8 @@ fn visit_knowledge_base(kb: KnowledgeBase, rules: List(Rule)) -> List(RuleError)
   |> list.append(acc)
 }
 
-// Extracts all the top level functions out of a glance module.
-fn extract_functions(from input: glance.Module) -> List(glance.Function) {
-  let glance.Module(functions: function_defs, ..) = input
-  let _functions =
-    list.map(function_defs, fn(def) {
-      let glance.Definition(_, func) = def
-      func
-    })
-}
-
 fn visit_module(input: glance.Module, rules: List(Rule)) -> List(RuleError) {
-  let glance.Module(constants: constants, ..) = input
-
-  let funcs = extract_functions(input)
+  let glance.Module(constants: constants, functions: functions, ..) = input
 
   let f = fn(location_identifier, expr) {
     apply_visitor(expr, rules, fn(rule) { rule.expression_visitors })
@@ -179,7 +167,10 @@ fn visit_module(input: glance.Module, rules: List(Rule)) -> List(RuleError) {
 
   // Visit all top level functions
   let results_after_functions: List(RuleError) = {
-    use acc0: List(RuleError), func <- list.fold(funcs, results_after_const)
+    use acc0: List(RuleError), glance.Definition(_, func) <- list.fold(
+      functions,
+      results_after_const,
+    )
 
     let errors_for_func: List(RuleError) =
       apply_visitor(func, rules, fn(rule) { rule.function_visitors })

--- a/src/review_config.gleam
+++ b/src/review_config.gleam
@@ -1,7 +1,12 @@
 import rule.{type Rule, Rule}
 import rules/no_panic
+import rules/no_trailing_underscore
 import rules/no_unnecessary_string_concatenation
 
 pub fn config() -> List(Rule) {
-  [no_panic.rule(), no_unnecessary_string_concatenation.rule()]
+  [
+    no_panic.rule(),
+    no_unnecessary_string_concatenation.rule(),
+    no_trailing_underscore.rule(),
+  ]
 }

--- a/src/rule.gleam
+++ b/src/rule.gleam
@@ -1,4 +1,5 @@
 import glance
+import gleam/list
 
 pub type Rule {
   Rule(
@@ -16,14 +17,33 @@ pub fn with_function_visitor(
   rule: Rule,
   visitor: fn(glance.Function) -> List(RuleError),
 ) {
-  Rule(..rule, function_visitors: [visitor, ..rule.function_visitors])
+  Rule(
+    ..rule,
+    function_visitors: [
+      set_rule_name_on_errors(rule.name, visitor),
+      ..rule.function_visitors
+    ],
+  )
 }
 
 pub fn with_expression_visitor(
   rule: Rule,
   visitor: fn(glance.Expression) -> List(RuleError),
 ) {
-  Rule(..rule, expression_visitors: [visitor, ..rule.expression_visitors])
+  Rule(
+    ..rule,
+    expression_visitors: [
+      set_rule_name_on_errors(rule.name, visitor),
+      ..rule.expression_visitors
+    ],
+  )
+}
+
+fn set_rule_name_on_errors(name: String, visitor: fn(a) -> List(RuleError)) {
+  fn(a: a) {
+    visitor(a)
+    |> list.map(fn(error) { RuleError(..error, rule: name) })
+  }
 }
 
 // Represents an error reported by a rule.

--- a/src/rule.gleam
+++ b/src/rule.gleam
@@ -3,12 +3,20 @@ import glance
 pub type Rule {
   Rule(
     name: String,
+    function_visitors: List(fn(glance.Function) -> List(RuleError)),
     expression_visitors: List(fn(glance.Expression) -> List(RuleError)),
   )
 }
 
 pub fn new(name: String) {
-  Rule(name: name, expression_visitors: [])
+  Rule(name: name, function_visitors: [], expression_visitors: [])
+}
+
+pub fn with_function_visitor(
+  rule: Rule,
+  visitor: fn(glance.Function) -> List(RuleError),
+) {
+  Rule(..rule, function_visitors: [visitor, ..rule.function_visitors])
 }
 
 pub fn with_expression_visitor(

--- a/src/rules/no_trailing_underscore.gleam
+++ b/src/rules/no_trailing_underscore.gleam
@@ -1,0 +1,19 @@
+import glance
+import gleam/string
+import rule.{type Rule, type RuleError}
+
+pub fn rule() -> Rule {
+  rule.new("NoTrailingUnderscore")
+  |> rule.with_function_visitor(function_visitor)
+}
+
+pub fn function_visitor(function: glance.Function) -> List(RuleError) {
+  case string.ends_with(function.name, "_") {
+    True -> [
+      rule.error(message: "Trailing underscore in function name", details: [
+        "We don't like no trailing underscores.",
+      ]),
+    ]
+    False -> []
+  }
+}

--- a/test/code_review_test.gleam
+++ b/test/code_review_test.gleam
@@ -2,6 +2,7 @@ import birdie
 import code_review
 import gleam/list
 import gleeunit
+import rule
 
 pub fn main() {
   gleeunit.main()
@@ -11,8 +12,8 @@ pub fn main() {
 // while there are lots of moving pieces.
 // 
 pub fn smoke_test() {
-  let assert Ok(rules) = code_review.run(on: "./snap_dummy")
-  use rule <- list.each(rules)
+  let assert Ok(rule_errors) = code_review.run(on: "./snap_dummy")
+  use rule: rule.RuleError <- list.each(rule_errors)
 
   rule
   |> code_review.display_rule_error


### PR DESCRIPTION
Adds a new visitor type for functions. We could potentially change it to also look at the entire definition, but that should be easily edited later. The important part (IMO) is that there is the mechanism for visiting more things.