### PR TITLE
refactoring

### DIFF
--- a/snap_dummy/src/panic_inside_use.gleam
+++ b/snap_dummy/src/panic_inside_use.gleam
@@ -2,6 +2,6 @@ import gleam/bool
 
 pub fn panic_inside_use() {
   use <- bool.guard(False, Nil)
-  Nil
+  let _ = Nil
   panic as "panic inside use"
 }

--- a/src/code_review.gleam
+++ b/src/code_review.gleam
@@ -1,7 +1,4 @@
-//// A linter for Gleam, written in Gleam. Staring with a very basic prototype setup:
-//// Read in the gleam files, iterate over them searching for common patterns
-//// based on the glance module that get's parsed, and produce messages pointing out 
-//// the issue.
+//// A linter for Gleam, written in Gleam. 
 
 import filepath
 import glance
@@ -11,12 +8,22 @@ import gleam/list
 import gleam/option.{None, Some}
 import gleam/result
 import gleam/string
-import review_config.{config}
-import rule.{type Rule, type RuleError, Rule, RuleError}
+import rule.{type Rule, type RuleViolation, Rule, RuleViolation}
+import rules/no_panic
+import rules/no_unnecessary_string_concatenation
 import simplifile
 import tom
 
-pub type WhingeError {
+const default_ruleset = [
+  no_panic.rule,
+  no_unnecessary_string_concatenation.rule,
+]
+
+/// The global error type for the linter.
+/// This is *NOT* related to the linting, it's
+/// the error type for the linter itself.
+/// 
+pub type CodeReviewError {
   CouldNotGetCurrentDirectory
   CouldNotGetSourceFiles
   CouldNotReadAllSourceFiles
@@ -25,7 +32,9 @@ pub type WhingeError {
   CouldNotParseGleamToml
 }
 
-fn whinge_error_to_error_message(input: WhingeError) -> String {
+/// Format an error for printing
+/// 
+fn code_review_error_to_error_message(input: CodeReviewError) -> String {
   case input {
     CouldNotGetCurrentDirectory -> "Error: Could not get current directory"
     CouldNotGetSourceFiles -> "Error: Could not get source files"
@@ -36,10 +45,11 @@ fn whinge_error_to_error_message(input: WhingeError) -> String {
   }
 }
 
-// Responsible for printing a rule error to the console
-// TODO: Just an initial repr for testing, someone good at making things pretty 
-// will need to update this
-pub fn display_rule_error(input: RuleError) -> String {
+/// Responsible for printing a rule error to the console
+/// TODO: Just an initial repr for testing, someone good at making things pretty 
+/// will need to update this
+///
+pub fn display_rule_violation(input: RuleViolation) -> String {
   "Path: "
   <> input.path
   <> "\n"
@@ -55,15 +65,20 @@ pub fn display_rule_error(input: RuleError) -> String {
 
 // Represents information the linter has access to. We want this to include
 // as much as possible and provide ergonomic accessors for querying it.
+//
 type KnowledgeBase {
   KnowledgeBase(
     // The gleam modules in the src folder
+    //
     src_modules: List(Module),
     // The gleam.toml
+    //
     gloml: Dict(String, tom.Toml),
   )
 }
 
+// Represents a parsed code module.
+//
 type Module {
   Module(
     // The "name" of the module is the path from the root
@@ -76,39 +91,46 @@ type Module {
   )
 }
 
-pub fn main() -> Result(Nil, WhingeError) {
+pub fn main() -> Result(Nil, CodeReviewError) {
   // Get the current directory
-  use curr_dir <- result.map(
+  use current_directory <- result.map(
     simplifile.current_directory()
     |> result.replace_error(CouldNotGetCurrentDirectory),
   )
 
   // Run the linter
-  case run(curr_dir) {
-    Ok(errors) ->
-      list.each(errors, fn(e) {
-        e
-        |> display_rule_error
-        |> io.println
-      })
-    Error(e) ->
-      io.print_error(
-        e
-        |> whinge_error_to_error_message,
-      )
+  case run(on: current_directory) {
+    // If everything worked okay, display
+    // each rule violation
+    Ok(rule_violations) -> {
+      use rule_violation <- list.each(rule_violations)
+      rule_violation
+      |> display_rule_violation
+      |> io.println
+    }
+    // If errored, print any errors that occured
+    Error(error) ->
+      error
+      |> code_review_error_to_error_message
+      |> io.print_error
   }
 }
 
 // Run the linter on a project at `directory`
-pub fn run(on directory: String) -> Result(List(RuleError), WhingeError) {
+pub fn run(on directory: String) -> Result(List(RuleViolation), CodeReviewError) {
+  // Read in all the information the linter needs to make decisions from the project
   use knowledge_base <- result.try(read_project(directory))
-  let errors = visit_knowledge_base(knowledge_base, config())
-  Ok(errors)
+
+  // Look over all the information to generate the rule violations
+  let rule_violations = search(over: knowledge_base, applying: default_ruleset)
+  Ok(rule_violations)
 }
 
 // Read's in all the information the linter needs 
 // from the project
-fn read_project(project_root_path: String) -> Result(KnowledgeBase, WhingeError) {
+fn read_project(
+  project_root_path: String,
+) -> Result(KnowledgeBase, CodeReviewError) {
   // Read and parse the gleam.toml
   use gloml_src <- result.try(
     simplifile.read(filepath.join(project_root_path, "gleam.toml"))
@@ -118,30 +140,41 @@ fn read_project(project_root_path: String) -> Result(KnowledgeBase, WhingeError)
     tom.parse(gloml_src)
     |> result.replace_error(CouldNotParseGleamToml),
   )
+
   // Read in the source modules
   use src_files <- result.try(
     simplifile.get_files(filepath.join(project_root_path, "src"))
     |> result.replace_error(CouldNotGetSourceFiles),
   )
 
-  use modules <- result.try(
-    list.try_map(src_files, fn(file) {
-      use content <- result.try(
-        simplifile.read(file)
-        |> result.replace_error(CouldNotReadAllSourceFiles),
-      )
-      use module <- result.try(
-        glance.module(content)
-        |> result.replace_error(CouldNotParseAllModules),
-      )
-      Ok(Module(file, module))
-    }),
-  )
+  // Parse the source files in "modules"
+  use modules <- result.try({
+    // map over the files
+    use file <- list.try_map(src_files)
+
+    // Read each files contents as src code
+    use content <- result.try(
+      simplifile.read(file)
+      |> result.replace_error(CouldNotReadAllSourceFiles),
+    )
+
+    // Try to parse the files content as source code
+    use module <- result.try(
+      glance.module(content)
+      |> result.replace_error(CouldNotParseAllModules),
+    )
+
+    // Return the parsed glance module indexed by the file path
+    Ok(Module(file, module))
+  })
 
   Ok(KnowledgeBase(src_modules: modules, gloml: gloml))
 }
 
-fn visit_knowledge_base(kb: KnowledgeBase, rules: List(Rule)) -> List(RuleError) {
+fn search(
+  over kb: KnowledgeBase,
+  applying rules: List(Rule),
+) -> List(RuleViolation) {
   use acc, Module(path, module) <- list.fold(kb.src_modules, [])
   visit_module(path, rules, module)
   |> list.append(acc)
@@ -151,30 +184,29 @@ fn visit_module(
   path: String,
   rules: List(Rule),
   input_module: glance.Module,
-) -> List(RuleError) {
+) -> List(RuleViolation) {
   visit_expressions(input_module, rules)
-  |> list.map(fn(error) { RuleError(..error, path: path) })
+  |> list.map(fn(error) { RuleViolation(..error, path: path) })
 }
 
 // Extracts all the top level functions out of a glance module.
 fn extract_functions(from input: glance.Module) -> List(glance.Function) {
   let glance.Module(functions: function_defs, ..) = input
-  let _functions =
-    list.map(function_defs, fn(def) {
-      let glance.Definition(_, func) = def
-      func
-    })
+  use glance.Definition(_, func) <- list.map(function_defs)
+  func
 }
 
+// Extracts all the constants out of a glance module
 fn extract_constants(from input: glance.Module) -> List(glance.Constant) {
   let glance.Module(constants: consts, ..) = input
-  list.map(consts, fn(const_) {
-    let glance.Definition(_, c) = const_
-    c
-  })
+  use glance.Definition(_, c) <- list.map(consts)
+  c
 }
 
-fn visit_expressions(input: glance.Module, rules: List(Rule)) -> List(RuleError) {
+fn visit_expressions(
+  input: glance.Module,
+  rules: List(Rule),
+) -> List(RuleViolation) {
   let funcs = extract_functions(input)
   let consts = extract_constants(input)
 
@@ -182,7 +214,7 @@ fn visit_expressions(input: glance.Module, rules: List(Rule)) -> List(RuleError)
     list.flat_map(rules, fn(rule) {
       list.flat_map(rule.expression_visitors, fn(visitor) { visitor(expr) })
       |> list.map(fn(error) {
-        RuleError(
+        RuleViolation(
           ..error,
           rule: rule.name,
           location_identifier: location_identifier,
@@ -192,7 +224,7 @@ fn visit_expressions(input: glance.Module, rules: List(Rule)) -> List(RuleError)
   }
 
   // Visit all the expressions in top level functions
-  let func_results: List(RuleError) = {
+  let func_results: List(RuleViolation) = {
     use func <- list.flat_map(funcs)
     use stmt <- list.flat_map(func.body)
 
@@ -207,7 +239,7 @@ fn visit_expressions(input: glance.Module, rules: List(Rule)) -> List(RuleError)
   }
 
   // Visit all the expressions in constants
-  let const_results: List(RuleError) =
+  let const_results: List(RuleViolation) =
     list.flat_map(consts, fn(c) {
       do_visit_expressions(c.value, [], fn(expr) { f(c.name, expr) })
     })

--- a/src/review_config.gleam
+++ b/src/review_config.gleam
@@ -1,7 +1,0 @@
-import rule.{type Rule, Rule}
-import rules/no_panic
-import rules/no_unnecessary_string_concatenation
-
-pub fn config() -> List(Rule) {
-  [no_panic.rule(), no_unnecessary_string_concatenation.rule()]
-}

--- a/src/rule.gleam
+++ b/src/rule.gleam
@@ -3,24 +3,13 @@ import glance
 pub type Rule {
   Rule(
     name: String,
-    expression_visitors: List(fn(glance.Expression) -> List(RuleError)),
+    expression_visitors: List(fn(glance.Expression) -> List(RuleViolation)),
   )
 }
 
-pub fn new(name: String) {
-  Rule(name: name, expression_visitors: [])
-}
-
-pub fn with_expression_visitor(
-  rule: Rule,
-  visitor: fn(glance.Expression) -> List(RuleError),
-) {
-  Rule(..rule, expression_visitors: [visitor, ..rule.expression_visitors])
-}
-
 // Represents an error reported by a rule.
-pub type RuleError {
-  RuleError(
+pub type RuleViolation {
+  RuleViolation(
     path: String,
     location_identifier: String,
     rule: String,
@@ -32,8 +21,8 @@ pub type RuleError {
 pub fn error(
   message message: String,
   details details: List(String),
-) -> RuleError {
-  RuleError(
+) -> RuleViolation {
+  RuleViolation(
     path: "",
     location_identifier: "",
     rule: "",

--- a/src/rules/no_panic.gleam
+++ b/src/rules/no_panic.gleam
@@ -1,12 +1,16 @@
+//// This rule checks the code for any panic statements. 
+
 import glance
-import rule.{type Rule, type RuleError}
+import rule.{type Rule, type RuleViolation, Rule}
 
-pub fn rule() -> Rule {
-  rule.new("NoPanic")
-  |> rule.with_expression_visitor(expression_visitor)
-}
+pub const rule = Rule(
+  name: "NoPanic",
+  expression_visitors: [check_expressions_for_panics],
+)
 
-pub fn expression_visitor(expr: glance.Expression) -> List(RuleError) {
+pub fn check_expressions_for_panics(
+  expr: glance.Expression,
+) -> List(RuleViolation) {
   case expr {
     glance.Panic(_) -> {
       [

--- a/src/rules/no_unnecessary_string_concatenation.gleam
+++ b/src/rules/no_unnecessary_string_concatenation.gleam
@@ -1,12 +1,19 @@
+//// This rule checks the code for unnecessary string literal concatenation, 
+//// like "a" <> "b" instead of just "ab".
+
 import glance
-import rule.{type Rule, type RuleError}
+import rule.{type Rule, type RuleViolation, Rule}
 
-pub fn rule() -> Rule {
-  rule.new("NoUnnecessaryStringConcatenation")
-  |> rule.with_expression_visitor(expression_visitor)
-}
+pub const rule = Rule(
+  name: "NoUnnecessaryStringConcatenation",
+  expression_visitors: [
+    check_binary_ops_for_unnecessary_string_literal_concatenation,
+  ],
+)
 
-pub fn expression_visitor(expr: glance.Expression) -> List(RuleError) {
+pub fn check_binary_ops_for_unnecessary_string_literal_concatenation(
+  expr: glance.Expression,
+) -> List(RuleViolation) {
   case expr {
     glance.BinaryOperator(glance.Concatenate, glance.String(""), _)
     | glance.BinaryOperator(glance.Concatenate, _, glance.String("")) -> {

--- a/test/code_review_test.gleam
+++ b/test/code_review_test.gleam
@@ -15,6 +15,6 @@ pub fn smoke_test() {
   use rule <- list.each(rules)
 
   rule
-  |> code_review.display_rule_error
+  |> code_review.display_rule_violation
   |> birdie.snap(title: rule.path)
 }


### PR DESCRIPTION
Did a little refactoring, trying to keep PRs small so going ahead and making one.
I got rid of the builder for rules. I like builders in general for public apis but it meant the ruleset couldn't be constant and we needed helper code for it when we can just construct the type directly internally.
I also renamed RuleError to RuleViolation, I think the word Error should be used for things that are proper errors in our application.
The rest is stylistic work, commenting, using `use` a little more, and trying to use some clearer naming patterns.