### PR TITLE
Add issue template for suggesting rules ideas

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-rule-idea.md
+++ b/.github/ISSUE_TEMPLATE/new-rule-idea.md
@@ -1,0 +1,54 @@
+---
+name: New rule idea
+about: Propose a new rule idea
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!-- This template may feel a bit too structured, so feel free to change the sections if they do not fit your style. I think that these questions are useful to think about though!
+
+Also the answer suggestions may feel a bit robotic, so definitely replace them with nice sentences.
+
+Don't forget to be respectful, and to give enough details for others to pitch in or give advice. Don't fret if you can't figure all of these out though, we'll discover these together!
+-->
+
+
+**What the rule should do:**
+
+
+**What problems does it solve:**
+
+
+**Example of things the rule would report:**
+
+```gleam
+
+```
+
+**Example of things the rule would not report:**
+
+```gleam
+
+```
+
+**When (not) to enable this rule:**
+
+<!-- It is useful to think when a rule would be especially valuable, and where it is counter-productive or just not useful.
+-->
+
+**I am looking for:**
+
+<!--
+- Feedback
+- Tips and help on how to implement it
+- Someone to implement it with/for me
+-->
+
+
+
+
+
+<!-- Thanks for writing all these helpful details. These are all useful details that you can use in the rule's documentation when you go implementing it, so this was definitely worth your investment.
+-->


### PR DESCRIPTION
This will make it so rule ideas get a lot more precise and helpful.
I use this template in all `elm-review` rule packages.