### PR TITLE
setup command

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -17,7 +17,6 @@ gleam = ">= 1.0.0"
 [dependencies]
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
 glance = ">= 0.8.2 and < 1.0.0"
-glance_printer = ">= 1.1.0 and < 2.0.0"
 simplifile = ">= 1.7.0 and < 2.0.0"
 filepath = ">= 1.0.0 and < 2.0.0"
 tom = ">= 0.3.0 and < 1.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,9 +5,7 @@ packages = [
   { name = "argv", version = "1.0.2", build_tools = ["gleam"], requirements = [], otp_app = "argv", source = "hex", outer_checksum = "BA1FF0929525DEBA1CE67256E5ADF77A7CDDFE729E3E3F57A5BDCAA031DED09D" },
   { name = "birdie", version = "1.1.2", build_tools = ["gleam"], requirements = ["argv", "filepath", "glance", "gleam_community_ansi", "gleam_erlang", "gleam_stdlib", "justin", "rank", "simplifile", "trie_again"], otp_app = "birdie", source = "hex", outer_checksum = "F9666AEB5F6EDFAE6ADF9DFBF10EF96A4EDBDDB84B854C29B9A3F615A6436311" },
   { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
-  { name = "glam", version = "1.3.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glam", source = "hex", outer_checksum = "02E0311862B9669C3E8CE73FA5A95D8FA457C6ACB48D95FBE808ABFAE0A1CEB0" },
   { name = "glance", version = "0.8.2", build_tools = ["gleam"], requirements = ["gleam_stdlib", "glexer"], otp_app = "glance", source = "hex", outer_checksum = "ACF09457E8B564AD7A0D823DAFDD326F58263C01ACB0D432A9BEFDEDD1DA8E73" },
-  { name = "glance_printer", version = "1.1.0", build_tools = ["gleam"], requirements = ["glam", "glance", "gleam_stdlib"], otp_app = "glance_printer", source = "hex", outer_checksum = "3140D4DD3F6C9119C60F2BA994F728D04E56014498A9C6C994814003EA115DE7" },
   { name = "gleam_community_ansi", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_community_colour", "gleam_stdlib"], otp_app = "gleam_community_ansi", source = "hex", outer_checksum = "FE79E08BF97009729259B6357EC058315B6FBB916FAD1C2FF9355115FEB0D3A4" },
   { name = "gleam_community_colour", version = "1.4.0", build_tools = ["gleam"], requirements = ["gleam_json", "gleam_stdlib"], otp_app = "gleam_community_colour", source = "hex", outer_checksum = "795964217EBEDB3DA656F5EB8F67D7AD22872EB95182042D3E7AFEF32D3FD2FE" },
   { name = "gleam_erlang", version = "0.25.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_erlang", source = "hex", outer_checksum = "054D571A7092D2A9727B3E5D183B7507DAB0DA41556EC9133606F09C15497373" },
@@ -27,7 +25,6 @@ packages = [
 birdie = { version = ">= 1.1.2 and < 2.0.0" }
 filepath = { version = ">= 1.0.0 and < 2.0.0" }
 glance = { version = ">= 0.8.2 and < 1.0.0" }
-glance_printer = { version = ">= 1.1.0 and < 2.0.0" }
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }
 simplifile = { version = ">= 1.7.0 and < 2.0.0" }

--- a/src/code_review.gleam
+++ b/src/code_review.gleam
@@ -13,8 +13,13 @@ import gleam/result
 
 // RUNNING THE LINTER ----------------------------------------------------------
 
-pub fn main(rules: List(Rule)) -> Nil {
-  case run(on: project.root(), with_rules: rules) {
+pub fn run(rules: List(Rule)) -> Nil {
+  let run_result = {
+    use knowledge_base <- result.try(project.read(project.root()))
+    Ok(visit(knowledge_base, rules))
+  }
+
+  case run_result {
     Ok(rule_errors) ->
       list.each(rule_errors, fn(rule_error) {
         rule.pretty_print_error(rule_error)
@@ -25,16 +30,6 @@ pub fn main(rules: List(Rule)) -> Nil {
       project.explain_error(project_error)
       |> io.println_error
   }
-}
-
-/// Run the linter for a project at the given path.
-///
-fn run(
-  on project_root: String,
-  with_rules rules: List(Rule),
-) -> Result(List(rule.Error), project.Error) {
-  use knowledge_base <- result.try(project.read(project_root))
-  Ok(visit(knowledge_base, rules))
 }
 
 /// TODO: once Gleam goes v1.1 this could be marked as internal, I don't think

--- a/src/code_review.gleam
+++ b/src/code_review.gleam
@@ -5,10 +5,6 @@
 
 import code_review/internal/project.{type Project}
 import code_review/rule.{type Rule}
-import code_review/rules/no_deprecated
-import code_review/rules/no_panic
-import code_review/rules/no_trailing_underscore
-import code_review/rules/no_unnecessary_string_concatenation
 import glance
 import gleam/io
 import gleam/list

--- a/src/code_review.gleam
+++ b/src/code_review.gleam
@@ -152,11 +152,11 @@ fn do_visit_expressions(
       visit_statements(rules, statements)
     }
     glance.RecordUpdate(
-        module: _,
-        constructor: _,
-        record: record,
-        fields: fields,
-      ) -> {
+      module: _,
+      constructor: _,
+      record: record,
+      fields: fields,
+    ) -> {
       let new_rules = do_visit_expressions(rules, record)
 
       use acc_rules, #(_, expr) <- list.fold(fields, new_rules)
@@ -174,11 +174,11 @@ fn do_visit_expressions(
       do_visit_expressions(rules, expr)
     }
     glance.FnCapture(
-        label: _,
-        function: function,
-        arguments_before: arguments_before,
-        arguments_after: arguments_after,
-      ) -> {
+      label: _,
+      function: function,
+      arguments_before: arguments_before,
+      arguments_after: arguments_after,
+    ) -> {
       list.fold(
         list.append(arguments_before, arguments_after),
         rules,

--- a/src/code_review/rules/no_unnecessary_string_concatenation.gleam
+++ b/src/code_review/rules/no_unnecessary_string_concatenation.gleam
@@ -43,10 +43,10 @@ fn expression_visitor(
     )
 
     glance.BinaryOperator(
-      glance.Concatenate,
-      glance.String(_),
-      glance.String(_),
-    ) -> #(
+        glance.Concatenate,
+        glance.String(_),
+        glance.String(_),
+      ) -> #(
       [
         rule.error(
           at: context.current_location,

--- a/src/code_review/rules/no_unnecessary_string_concatenation.gleam
+++ b/src/code_review/rules/no_unnecessary_string_concatenation.gleam
@@ -43,10 +43,10 @@ fn expression_visitor(
     )
 
     glance.BinaryOperator(
-        glance.Concatenate,
-        glance.String(_),
-        glance.String(_),
-      ) -> #(
+      glance.Concatenate,
+      glance.String(_),
+      glance.String(_),
+    ) -> #(
       [
         rule.error(
           at: context.current_location,

--- a/src/code_review/setup.gleam
+++ b/src/code_review/setup.gleam
@@ -1,0 +1,31 @@
+import filepath
+import simplifile
+
+const review_file_name = "review.gleam"
+
+const init_setup_src = "
+import code_review
+import code_review/rules/no_panic
+import code_review/rules/no_unnecessary_string_concatenation
+import code_review/rules/no_trailing_underscore
+import code_review/rules/no_deprecated
+
+pub fn main() {
+  let rules = [
+    no_panic.rule(),
+    no_unnecessary_string_concatenation.rule(),
+    no_trailing_underscore.rule(),
+    no_deprecated.rule(),
+  ]
+  code_review.main(rules)
+}
+"
+
+pub fn main() {
+  let assert Ok(curr_dir) = simplifile.current_directory()
+  let assert Ok(_) =
+    simplifile.write(
+      filepath.join(curr_dir, "test/" <> review_file_name),
+      init_setup_src,
+    )
+}

--- a/src/code_review/setup.gleam
+++ b/src/code_review/setup.gleam
@@ -17,7 +17,7 @@ pub fn main() {
     no_trailing_underscore.rule(),
     no_deprecated.rule(),
   ]
-  code_review.main(rules)
+  code_review.run(rules)
 }
 "
 


### PR DESCRIPTION
This PR
1. Removes the unsused glance_printer dependency
2. Adds the setup command. The flow is the user runs `gleam run -m code_review/setup`, which creates the review.gleam file with default contents in their test directory which they can configure, and then they just have to run `gleam run -m review` to run the lints.

We can add proper error handling and whatnot around this later in the process